### PR TITLE
Avoid sending an empty line in single command mode

### DIFF
--- a/rust-rcon-perl
+++ b/rust-rcon-perl
@@ -123,7 +123,7 @@ my $socket; # socket handle
 my $logfilefh; #log file handle
 
 my $single_command_only = 0;		# flag, execute a single command and exit
-my @single_command_list = "";		# 	command for above
+my @single_command_list ;		# 	command for above
 my $suppress_status_messages = 0;	# flag, if enabled will disable connection status messages
 
 my $parsed_hostname = "";

--- a/rust-rcon-perl-noansi
+++ b/rust-rcon-perl-noansi
@@ -123,7 +123,7 @@ my $socket; # socket handle
 my $logfilefh; #log file handle
 
 my $single_command_only = 0;		# flag, execute a single command and exit
-my @single_command_list = "";		# 	command for above
+my @single_command_list;		# 	command for above
 my $suppress_status_messages = 0;	# flag, if enabled will disable connection status messages
 
 my $parsed_hostname = "";


### PR DESCRIPTION
When running in single command mode, an error message "Command not found" is issued. The reason is, that the given commands are appended to a empty string array, so the first command is an empty string:

```
$ ./rust-rcon-perl -s 127.0.0.1 -p 28016 -w xxx   -xq 'status'
Command not found
hostname: AoD
version : 1341 secure (secure mode enabled, connected to Steam3)
map     : Procedural Map
players : 0 (10 max)

id name ping connected addr owner violation 
```

With patch

```
 ./rust-rcon-perl -s 127.0.0.1 -p 28016 -w xxx  -xq 'status'
hostname: AoD
version : 1341 secure (secure mode enabled, connected to Steam3)
map     : Procedural Map
players : 0 (10 max)

id name ping connected addr owner violation 
```
